### PR TITLE
Fix RTD config

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,7 +4,7 @@ build:
   tools:
     python: "3.11"
 sphinx:
-  configuration: docs/conf.py
+  configuration: conf.py
 python:
   install:
     - requirements: requirements.txt

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,4 +1,10 @@
+version: 2
 build:
-  image: latest
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+sphinx:
+  configuration: docs/conf.py
 python:
-  version: 3.6
+  install:
+    - requirements: requirements.txt


### PR DESCRIPTION
> Your project(s) "icb-anndata-tutorials, icb-scanpy-tutorials, icb-scvelo" don't have a configuration file. Configuration files will soon be required by projects, and will no longer be optional. [Read our blog post to create one](https://blog.readthedocs.com/migrate-configuration-v2/) and ensure your project continues building successfully.