### PR TITLE
(fix): scanorama notebook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,8 @@ scripts/
 test_notebooks.txt
 upload_to_pypi.sh
 
+# Ignore biomart file
+.pybiomart.sqlite
 
 # always-ignore extensions
 *~


### PR DESCRIPTION
Towards #79, things need to actually be runable somewhere and this starts that process.  Hopefully in the future we can cache outputs.  We can also completely deprecate this notebook if we don't want to use it anymore and just redirect to https://squidpy.readthedocs.io/en/stable/notebooks/tutorials/tutorial_tangram.html