### PR TITLE
Fixed typo ('very' to 'vary')

### DIFF
--- a/basic-scrna-tutorial.ipynb
+++ b/basic-scrna-tutorial.ipynb
@@ -273,7 +273,7 @@
    "source": [
     "Based on the QC metric plots, one could now remove cells that have too many mitochondrial genes expressed or too many total counts by setting manual or automatic thresholds. However, sometimes what appears to be poor QC metrics can be driven by real biology so we suggest starting with a very permissive filtering strategy and revisiting it at a later point. We therefore now only filter cells with less than 100 genes expressed and genes that are detected in less than 3 cells. \n",
     "\n",
-    "Additionally, it is important to note that for datasets with multiple batches, quality control should be performed for each sample individually as quality control thresholds can very substantially between batches. "
+    "Additionally, it is important to note that for datasets with multiple batches, quality control should be performed for each sample individually as quality control thresholds can vary substantially between batches. "
    ]
   },
   {


### PR DESCRIPTION
Hey, I catched a typo in the basic-scrna-tutorial.ipynb tutorial. This is a very simple pull request to fix it.