### PR TITLE
Fix typo: constuction -> construction

### DIFF
--- a/basic-scrna-tutorial.ipynb
+++ b/basic-scrna-tutorial.ipynb
@@ -508,7 +508,7 @@
    "id": "27147fca-c120-468d-8a5c-6479ece27848",
    "metadata": {},
    "source": [
-    "## Nearest neighbor graph constuction and visualization\n",
+    "## Nearest neighbor graph construction and visualization\n",
     "\n",
     "Let us compute the neighborhood graph of cells using the PCA representation of the data matrix."
    ]


### PR DESCRIPTION
Just a typo that I cought while browsing the docs.