### PR TITLE
Fix broken ecosystem ref link in ingest tutorial

### DIFF
--- a/integrating-data-using-ingest.ipynb
+++ b/integrating-data-using-ingest.ipynb
@@ -33,7 +33,7 @@
     "\n",
     "We refer to this *asymmetric* dataset integration as *ingesting* annotations from an annotated reference `adata_ref` into an `adata` that still lacks this annotation.\n",
     "It is different from learning a joint representation that integrates datasets in a symmetric way as [BBKNN](https://github.com/Teichlab/bbknn), Scanorma, Conos, CCA (e.g. in Seurat) or a conditional VAE (e.g. in scVI, trVAE) would do, but comparable to the initiall MNN implementation in scran.\n",
-    "Take a look at tools in the {ref}`external API <external-data-integration>` or at the {ref}`ecoystem page <eco-data-integration>` to get a start with other tools."
+    "Take a look at tools in the {ref}`external API <external-data-integration>` or at the [scverse ecosystem](https://scverse.org/packages/#ecosystem) to get a start with other tools."
    ]
   },
   {


### PR DESCRIPTION
## Summary
- The `integrating-data-using-ingest` notebook references `{ref}\`ecoystem page <eco-data-integration>\`` which no longer resolves against scanpy's docs (and had a typo to boot).
- Replaced it with a direct link to the [scverse ecosystem page](https://scverse.org/packages/#ecosystem) so the rendered tutorial doesn't ship a broken cross-ref.

## Test plan
- [ ] Notebook renders without an unresolved-reference warning in the scanpy docs build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)